### PR TITLE
Add jwt-decode for decoding JWT tokens in AuthService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ngrx/router-store": "^18.1.1",
         "@ngrx/store": "^18.1.1",
         "@ngrx/store-devtools": "^18.1.1",
+        "jwt-decode": "^4.0.0",
         "primeicons": "^7.0.0",
         "primeng": "^17.18.11",
         "rxjs": "~7.8.0",
@@ -8781,6 +8782,15 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/karma": {
       "version": "6.4.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@ngrx/router-store": "^18.1.1",
     "@ngrx/store": "^18.1.1",
     "@ngrx/store-devtools": "^18.1.1",
+    "jwt-decode": "^4.0.0",
     "primeicons": "^7.0.0",
     "primeng": "^17.18.11",
     "rxjs": "~7.8.0",

--- a/src/app/admin/core/services/auth.service.ts
+++ b/src/app/admin/core/services/auth.service.ts
@@ -4,6 +4,7 @@ import { ILogin, ILoginResponse } from '../models/auth.model';
 import { apiEndpoint } from '../constants';
 import { map, Observable } from 'rxjs';
 import { TokenService } from './token.service';
+import { jwtDecode } from 'jwt-decode';
 
 @Injectable({
   providedIn: 'root',
@@ -22,7 +23,10 @@ export class AuthService {
           if (response) {
             this.tokenService.setToken(response.accessToken);
           }
-          return response;
+          return {
+            ...response,
+            ...jwtDecode(response.accessToken),
+          };
         })
       );
   }

--- a/src/app/admin/core/store/auth.actions.ts
+++ b/src/app/admin/core/store/auth.actions.ts
@@ -1,11 +1,12 @@
 import { createActionGroup, props } from "@ngrx/store";
 import { ILogin, ILoginResponse } from "../models/auth.model";
+import { AuthData } from "./auth.reducer";
 
 export const AuthActions = createActionGroup({
   source: 'Auth API',
   events: {
     'Login': props<ILogin>(),
-    'Login Success': props<ILoginResponse>(),
+    'Login Success': props<{payload: AuthData}>(),
     'Login Failure': props<{ serverError: string }>(),
   },
 });

--- a/src/app/admin/core/store/auth.effects.ts
+++ b/src/app/admin/core/store/auth.effects.ts
@@ -12,9 +12,9 @@ export class AuthEffects {
   login$ = createEffect(() =>
     this.actions$.pipe(
       ofType(AuthActions.login),
-      exhaustMap(credential =>
+      exhaustMap((credential) =>
         this.authService.login(credential).pipe(
-          map((accessToken) => AuthActions.loginSuccess(accessToken)),
+          map((accessToken) => AuthActions.loginSuccess({payload: accessToken} )),
           catchError((err) =>
             of(AuthActions.loginFailure({ serverError: err.statusText }))
           )

--- a/src/app/admin/core/store/auth.reducer.ts
+++ b/src/app/admin/core/store/auth.reducer.ts
@@ -1,25 +1,34 @@
-import { createReducer, on } from "@ngrx/store";
-import { AuthActions } from "./auth.actions";
-import { ILoginResponse } from "../models/auth.model";
+import { createReducer, on } from '@ngrx/store';
+import { AuthActions } from './auth.actions';
+import { ILoginResponse } from '../models/auth.model';
 
+export const AUTH_FEATURENAME = 'auth';
 
-export const AUTH_FEATURENAME = "auth"
+export interface AuthData {
+  accessToken: string;
+  /**
+   *  user ID from of sever DB
+   */
+  id?: number;
+  iat?: number;
+  /**
+   *  timestamp of expiring
+   */
+  exp?: number;
+}
 
-// export interface AuthData { // ILoginResponse
-//     accessToken: string;
-// }
 export interface AuthState {
   loading: boolean;
   loaded: boolean;
   serverError: string;
-  authData?: ILoginResponse;
+  authData?: AuthData;
 }
 
 export const initialState: AuthState = {
-    loading: false,
-    loaded: true,
-    serverError: ''
-}
+  loading: false,
+  loaded: true,
+  serverError: '',
+};
 
 export const authReducer = createReducer(
   initialState,
@@ -28,12 +37,12 @@ export const authReducer = createReducer(
     loading: true,
     serverError: '',
   })),
-  on(AuthActions.loginSuccess, (state, authData: ILoginResponse) => ({
+  on(AuthActions.loginSuccess, (state, action) => ({
     ...state,
     loaded: true,
     loading: false,
     serverError: '',
-    authData,
+    authData: action.payload,
   })),
   on(AuthActions.loginFailure, (state, { serverError }) => ({
     ...state,


### PR DESCRIPTION
Added additional data ('iat', 'exp', etc. data from JWT after decoded) to authData field in the store

Added the `jwt-decode` package to decode JWT tokens in the `AuthService`. Updated the `AuthService` to include decoded token data in the login response. Also, modified the `AuthActions`, `AuthEffects`, and `AuthReducer` to handle the decoded token data appropriately.

